### PR TITLE
Fix `format` not being called on correct string

### DIFF
--- a/locust-tools/locustfile.py
+++ b/locust-tools/locustfile.py
@@ -80,7 +80,7 @@ def generate_tasks():
     with open("/tmp/outfile") as f:
         content = f.readlines()
     for q in content:
-        tasks.append(create_task("/api/v1/query_range?query={}&&start=2018-07-22T00:00:00.00Z&end="+datetime.datetime.utcnow().strftime("%Y-%m-%d")+"T23:59:00.0Z&step=15m".format(q)))
+        tasks.append(create_task("/api/v1/query_range?query={}&&start=2018-07-22T00:00:00.00Z&end=".format(q) + datetime.datetime.utcnow().strftime("%Y-%m-%d") + "T23:59:00.0Z&step=15m"))
     return tasks
 
 class UserBehavior(TaskSet):


### PR DESCRIPTION
Since adding string concatenation, we had forgotten to move
`format` on to the end of the string that we actually wished to
insert the `q` query variables.